### PR TITLE
Downstream changes from Tabletop Soc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ importlib-metadata==3.4.0
 Markdown==3.3.3
 oauthlib==3.1.0
 packaging==20.9
-#psycopg2==2.8.6
+psycopg2==2.8.6
 pycparser==2.20
 PyJWT==2.0.1
 pymdown-extensions==8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ importlib-metadata==3.4.0
 Markdown==3.3.3
 oauthlib==3.1.0
 packaging==20.9
-psycopg2==2.8.6
+#psycopg2==2.8.6
 pycparser==2.20
 PyJWT==2.0.1
 pymdown-extensions==8.1.1

--- a/votes/admin.py
+++ b/votes/admin.py
@@ -3,6 +3,12 @@ from django.contrib import admin
 from .models import Election, Candidate, Ticket, FPTPVote, APRVVote, STVVote, STVPreference, STVResult
 
 
+def archive(modeladmin, request, queryset):
+    queryset.filter(open=False).update(archived=True)
+
+archive.short_description = "Archive selected elections (if closed)"
+
+
 class PreferenceInline(admin.StackedInline):
     model = STVPreference
     readonly_fields = ['order', 'candidate']
@@ -20,13 +26,13 @@ class FPTPVoteAdmin(admin.ModelAdmin):
     search_fields = ['uuid']
 
 
-class STVVoteAdmin(admin.ModelAdmin):
-    inlines = [PreferenceInline]
-    readonly_fields = ['election', 'uuid', 'time', 'selection']
+class TicketAdmin(admin.ModelAdmin):
     search_fields = ['uuid']
 
 
-class TicketAdmin(admin.ModelAdmin):
+class STVVoteAdmin(admin.ModelAdmin):
+    inlines = [PreferenceInline]
+    readonly_fields = ['election', 'uuid', 'time', 'selection']
     search_fields = ['uuid']
 
 
@@ -36,6 +42,9 @@ class STVResultAdmin(admin.ModelAdmin):
 
 class ElectionAdmin(admin.ModelAdmin):
     inlines = [CandidateInline]
+    actions = [archive]
+    list_filter = ['archived','open', 'vote_type']
+    list_display = ['__str__', 'open','vote_type']
 
 
 # Register your models here.

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -34,7 +34,7 @@ class CandidateForm(ModelForm):
 class IDTicketForm(Form):
     ids = CharField(help_text="A list of whitespace separated uni-ids",
                     widget=Textarea(), label="IDs")
-    elections = ModelMultipleChoiceField(Election.objects.all())
+    elections = ModelMultipleChoiceField(Election.objects.filter(archived=False))
 
 
 class DeleteTicketForm(Form):

--- a/votes/forms.py
+++ b/votes/forms.py
@@ -1,7 +1,9 @@
-from django.forms import Form, ModelForm, Textarea, ModelMultipleChoiceField, CharField
+from django.core.exceptions import ValidationError
+from django.forms import Form, ModelForm, Textarea, \
+    ModelMultipleChoiceField, CharField, UUIDField
 from django.urls import reverse_lazy
 
-from .models import Election, Candidate
+from .models import Election, Candidate, Ticket
 
 MD_INPUT_SAFE = {
     'class': 'markdown-input',
@@ -17,7 +19,8 @@ MD_INPUT_TEXT = {
 class ElectionForm(ModelForm):
     class Meta:
         model = Election
-        fields = ['name', 'description', 'vote_type', 'max_votes', 'seats', 'open']
+        fields = ['name', 'description', 'vote_type',
+                  'max_votes', 'seats', 'open']
         widgets = {'description': Textarea(attrs=MD_INPUT_SAFE)}
 
 
@@ -28,6 +31,26 @@ class CandidateForm(ModelForm):
         widgets = {'description': Textarea(attrs=MD_INPUT_TEXT)}
 
 
-class DateTicketForm(Form):
-    ids = CharField(help_text="A list of whitespace separated uni-ids", widget=Textarea(), label="IDs")
+class IDTicketForm(Form):
+    ids = CharField(help_text="A list of whitespace separated uni-ids",
+                    widget=Textarea(), label="IDs")
     elections = ModelMultipleChoiceField(Election.objects.all())
+
+
+class DeleteTicketForm(Form):
+    elections = ModelMultipleChoiceField(
+        Election.objects.filter(archived=False, open=False))
+
+
+class NullForm(Form):
+    pass
+
+
+class ResetVoteForm(Form):
+    uuid = UUIDField(label="Ticket UUID")
+
+    def clean_uuid(self):
+        uuid_value = self.cleaned_data['uuid']
+        if not Ticket.objects.filter(spent=True, uuid=uuid_value).exists():
+            raise ValidationError("Incorrect UUID")
+        return uuid_value

--- a/votes/models.py
+++ b/votes/models.py
@@ -14,7 +14,8 @@ class Election(models.Model):
     vote_type = models.IntegerField(choices=Types.choices, default=Types.FPTP)
     max_votes = models.IntegerField(default=2,
                                     help_text="Ignored except in Plurality. Number of candidates selectable per vote")
-    seats = models.IntegerField(default=1, help_text="Ignored except in STV. Number of people who can win")
+    seats = models.IntegerField(
+        default=1, help_text="Ignored except in STV. Number of people who can win")
     open = models.BooleanField(default=False)
     archived = models.BooleanField(default=False)
 

--- a/votes/stv.py
+++ b/votes/stv.py
@@ -137,7 +137,8 @@ class Election:
 
         if surplus == 0 or surplus >= self.previous_surplus:
             # B3
-            sorted_results = sorted(filter(lambda x: x[0].status == States.HOPEFUL, scores.items()), key=itemgetter(1))
+            sorted_results = sorted(filter(
+                lambda x: x[0].status == States.HOPEFUL, scores.items()), key=itemgetter(1))
             min_score = sorted_results[0][1]
             eliminated_candidate: Candidate = self._choose(
                 list(filter(lambda x: x[1] <= min_score + surplus, sorted_results)))
@@ -147,7 +148,8 @@ class Election:
             # B2f
             for candidate in self.candidates:
                 if candidate.status == States.ELECTED:
-                    candidate.keep_factor = Fraction(candidate.keep_factor * quota, scores[candidate])
+                    candidate.keep_factor = Fraction(
+                        candidate.keep_factor * quota, scores[candidate])
         self.previous_surplus = surplus
         self._log(scores, wastage)
 
@@ -171,7 +173,8 @@ class Election:
         self._addlog("======")
         for i in self.candidates:
             assert isinstance(i, Candidate)
-            self._addlog("Candidate:", i.id, i.keep_factor.limit_denominator(1000))
+            self._addlog("Candidate:", i.id,
+                         i.keep_factor.limit_denominator(1000))
             self._addlog("Status:", str(i.status))
             self._addlog("Votes:", str(scores[i].limit_denominator(1000)))
             self._addlog()
@@ -212,7 +215,8 @@ def fptp_equivalent():
 
 def immediate_majority():
     c = {1, 2, 3, 4}
-    v = [(1, 2, 3, 4)] * 9 + [(2, 3, 1, 4)] * 4 + [(3, 1, 4, 2)] * 3 + [(4, 1)] * 2
+    v = [(1, 2, 3, 4)] * 9 + [(2, 3, 1, 4)] * \
+        4 + [(3, 1, 4, 2)] * 3 + [(4, 1)] * 2
     e = Election(c, v, 1)
     e.full_election()
 
@@ -226,7 +230,8 @@ def delayed_majority():
 
 def delayeder_majority():
     c = {1, 2, 3, 4}
-    v = [(4, 2, 1, 3)] * 4 + [(3, 2, 4, 1)] * 5 + [(2, 1, 4, 3)] + [(1, 4, 2, 3)]
+    v = [(4, 2, 1, 3)] * 4 + [(3, 2, 4, 1)] * \
+        5 + [(2, 1, 4, 3)] + [(1, 4, 2, 3)]
     e = Election(c, v, 1)
     e.full_election()
 
@@ -241,7 +246,8 @@ def two_available_three():
 
 def two_available_four():
     c = {1, 2, 3, 4}
-    v = [(4, 2, 1, 3)] * 4 + [(3, 2, 4, 1)] * 5 + [(2, 1, 4, 3)] * 3 + [(1, 4, 2, 3)] * 2
+    v = [(4, 2, 1, 3)] * 4 + [(3, 2, 4, 1)] * 5 + \
+        [(2, 1, 4, 3)] * 3 + [(1, 4, 2, 3)] * 2
     e = Election(c, v, 2)
     e.full_election()
 

--- a/votes/templates/votes/admin.html
+++ b/votes/templates/votes/admin.html
@@ -1,4 +1,5 @@
 {% extends 'main.html' %}
+{% load vote_tags %}
 
 {% block title %}Votes{% endblock %}
 {% block pagetitle %}Votes{% endblock %}
@@ -10,8 +11,8 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
-        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
+    {% if perms.votes.change_election %}
+        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:app_list" "votes" %}">Edit</a>
     {% endif %}
 {% endblock %}
 
@@ -26,7 +27,7 @@
     <p>
         <a href="{% url "votes:tickets" %}"
            class="btn btn-outline-success btn-block">
-            Issue Tickets
+            Manage Tickets
         </a>
     </p>
     <div class="list-group mb-3">
@@ -37,16 +38,40 @@
             </a>
         {% endfor %}
     </div>
-    <h2>Results</h2>
-    <div class="list-group">
-        {% for election in object_list %}
-            {% if election.open %}
-            {% else %}
-            <a href="{% url "votes:results" election.id %}"
-               class="list-group-item list-group-item-action">
-                {{ election.name }}
+
+    {% if open_elections %}
+        <p>
+            <a href="{% url "votes:reset_vote" %}"
+               class="btn btn-outline-danger btn-block">
+                Reset User Vote
             </a>
-            {% endif %}
-        {% endfor %}
-    </div>
+        </p>
+        <h2>Live Votes</h2>
+        <ul class="list-group mb-3">
+            {% for election in open_elections %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    {{ election.name }}
+                    <span class="badge badge-primary badge-pill">{{ election|sanitized_vote_count }}</span>
+                </li>
+            {% endfor %}
+        </ul>
+        <form class="mb-3" method="post" action="{% url "votes:close" %}">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-outline-success btn-block">
+                Close all votes
+            </button>
+        </form>
+
+    {% endif %}
+    {% if closed_elections %}
+        <h2>Results</h2>
+        <div class="list-group">
+            {% for election in closed_elections %}
+                <a href="{% url "votes:results" election.id %}"
+                   class="list-group-item list-group-item-action">
+                    {{ election.name }}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/votes/templates/votes/approval_done.html
+++ b/votes/templates/votes/approval_done.html
@@ -10,13 +10,6 @@
 {% endblock %}
 {% block breadcrumbs_child %}Complete{% endblock %}
 
-{% block leftcontents %}
-    {{ block.super }}
-    {% if perms.votes.change_elections %}
-        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
-    {% endif %}
-{% endblock %}
-
 {% block body %}
     <div class="card">
         <div class="card-body">

--- a/votes/templates/votes/approval_results.html
+++ b/votes/templates/votes/approval_results.html
@@ -12,8 +12,8 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
-        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
+    {% if perms.votes.change_election %}
+        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_change" election.id %}">Edit</a>
     {% endif %}
 {% endblock %}
 

--- a/votes/templates/votes/approval_votescreen.html
+++ b/votes/templates/votes/approval_votescreen.html
@@ -11,8 +11,8 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
-        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
+    {% if perms.votes.change_election %}
+        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_change" election.id %}">Edit</a>
     {% endif %}
 {% endblock %}
 

--- a/votes/templates/votes/create_candidate.html
+++ b/votes/templates/votes/create_candidate.html
@@ -2,7 +2,7 @@
 {% load markdown_tags %}
 
 {% block title %}Edit - Votes{% endblock %}
-{% block pagetitle %}{% if object %}Edit{% else %}Create{% endif %} Election{% endblock %}
+{% block pagetitle %}{% if object %}Edit{% else %}Create{% endif %} Candidate{% endblock %}
 
 {% block breadcrumbs_parents %}
     <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>

--- a/votes/templates/votes/delete_tickets.html
+++ b/votes/templates/votes/delete_tickets.html
@@ -2,15 +2,15 @@
 {% load markdown_tags %}
 
 {% block title %}Tickets - Votes{% endblock %}
-{% block pagetitle %}Issue Tickets{% endblock %}
+{% block pagetitle %}Delete Tickets{% endblock %}
 
 {% block breadcrumbs_parents %}
     <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>
     <li class="breadcrumb-item"><a href="{% url 'votes:admin' %}">Admin</a></li>
     <li class="breadcrumb-item"><a href="{% url 'votes:tickets' %}">Tickets</a></li>
 {% endblock %}
-{% block breadcrumbs_child %}Create{% endblock %}
+{% block breadcrumbs_child %}Delete{% endblock %}
 
 {% block body %}
-    {% include "parts/render_form.html" %}
+    {% include "parts/render_form.html" with colour="danger" save="Delete" %}
 {% endblock %}

--- a/votes/templates/votes/home.html
+++ b/votes/templates/votes/home.html
@@ -1,4 +1,5 @@
 {% extends 'main.html' %}
+{% load vote_tags %}
 
 {% block title %}Votes{% endblock %}
 {% block pagetitle %}Votes{% endblock %}
@@ -7,13 +8,13 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
+    {% if perms.votes.change_election %}
         <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
     {% endif %}
 {% endblock %}
 
 {% block body %}
-    {% if perms.votes.change_elections %}
+    {% if perms.votes.change_election %}
     <p>
         <a href="{% url "votes:admin" %}"
            class="btn btn-outline-warning btn-block">
@@ -23,10 +24,18 @@
     {% endif %}
     <div class="list-group">
         {% for election in object_list %}
-            <a href="{% url "votes:vote" election.id %}"
-               class="list-group-item list-group-item-action">
-                {{ election.name }}
-            </a>
+            {% current_user_ticket election as ticket %}
+            {% if ticket.spent %}
+                <p href="{% url "votes:vote" election.id %}"
+                   class="list-group-item list-group-item-light" data-toggle="tooltip" data-placement="top" title="Already Voted">
+                    <i class="fas fa-vote-yea fa-fw"></i> {{ election.name }}
+                </p>
+            {% else %}
+                <a href="{% url "votes:vote" election.id %}"
+                   class="list-group-item list-group-item-action">
+                    <i class="fas fa-file-alt fa-fw"></i> {{ election.name }}
+                </a>
+            {% endif %}
         {% empty %}
             <div class="list-group-item text-muted">No elections currently available. Please check back later.</div>
         {% endfor %}

--- a/votes/templates/votes/reset_vote.html
+++ b/votes/templates/votes/reset_vote.html
@@ -1,0 +1,34 @@
+{% extends 'main.html' %}
+{% load markdown_tags %}
+
+{% block title %}Reset - Votes{% endblock %}
+{% block pagetitle %}Reset Vote{% endblock %}
+
+{% block breadcrumbs_parents %}
+    <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'votes:admin' %}">Admin</a></li>
+{% endblock %}
+{% block breadcrumbs_child %}Reset Vote{% endblock %}
+
+{% block body %}
+    <div class="card bg-warning mb-3">
+        <h3 class="card-header"><i class="fas fa-exclamation-triangle"></i> Warning</h3>
+        <div class="card-body">
+            <p class="card-text">
+                You should <strong>only</strong> do this at the behest of the person who cast it,
+                and only if they are sure that they want the vote reset.
+            </p>
+            <p class="card-text">
+                If you are even slightly unsure that the vote UUID might not be theirs, you shouldn't delete it.
+            </p>
+            <p class="card-text">
+                This section of the voting system is by far the quickest way to invalidate the election,
+                so please be careful.
+            </p>
+        </div>
+    </div>
+    <p class="card-text">
+        This deletes a specific vote from the election by UUID. Once the vote has been deleted through this method, the user will once again be able to cast a vote in that election.
+    </p>
+    {% include "parts/render_form.html" with colour="danger" save="Reset Vote" %}
+{% endblock %}

--- a/votes/templates/votes/stv_results.html
+++ b/votes/templates/votes/stv_results.html
@@ -10,8 +10,18 @@
             </div>
         {% endfor %}
     </div>
+    <h3>Breakdown</h3>
+    <div class="list-group mb-2">
+        {% for i in election.candidate_set.all|dictsort:"id" %}
+            <p class="list-group-item"><strong class="d-inline-block align-middle mr-2" style="width: 2rem">{{ i.id }}</strong><span class="d-inline-block align-middle">{{ i.name }}</span></p>
+        {% endfor %}
+    </div>
     <pre>{{ result.full_log }}</pre>
-    <p>
-        <a class="btn btn-block btn-outline-dark" href="{% url "votes:stv_all_votes" election.id %}">See Votes</a>
-    </p>
+{% endblock %}
+
+{% block leftcontents %}
+    {{ block.super }}
+    {% if perms.votes.change_results %}
+        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_stvresult_change" result.id %}">Edit Result</a>
+    {% endif %}
 {% endblock %}

--- a/votes/templates/votes/stv_vote_list.html
+++ b/votes/templates/votes/stv_vote_list.html
@@ -13,7 +13,7 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
+    {% if perms.votes.change_election %}
         <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
     {% endif %}
 {% endblock %}

--- a/votes/templates/votes/stv_votescreen.html
+++ b/votes/templates/votes/stv_votescreen.html
@@ -11,7 +11,7 @@
 
 {% block leftcontents %}
     {{ block.super }}
-    {% if perms.votes.change_elections %}
+    {% if perms.votes.change_election %}
         <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_election_changelist" %}">Edit</a>
     {% endif %}
 {% endblock %}
@@ -64,8 +64,8 @@
                 <div id="sortable_reject" class="card-body">
                     {% for choice in choices %}
                         <div class="card mb-3" data-voteid="{{ choice.formid }}">
-                            <label class="mb-0 card-header" for="{{ choice.formid }}" class="">
-                                {{ choice.name }}
+                            <label class="mb-0 card-header" for="{{ choice.formid }}">
+                                <strong>{{ choice.name }}</strong>
                             </label>
                             {% if choice.description|parse_md_safe %}
                                 <div class="card-body markdown-text">

--- a/votes/templates/votes/ticket.html
+++ b/votes/templates/votes/ticket.html
@@ -1,0 +1,34 @@
+{% extends 'main.html' %}
+
+{% block title %}Votes{% endblock %}
+{% block pagetitle %}Votes{% endblock %}
+
+{% block breadcrumbs_parents %}
+    <li class="breadcrumb-item"><a href="{% url 'votes:elections' %}">Votes</a></li>
+    <li class="breadcrumb-item"><a href="{% url 'votes:admin' %}">Admin</a></li>
+{% endblock %}
+{% block breadcrumbs_child %}Tickets{% endblock %}
+
+{% block leftcontents %}
+    {{ block.super }}
+    {% if perms.votes.change_tickets %}
+        <a class="btn btn-block btn-outline-dark mb-3" href="{% url "admin:votes_ticket_changelist" %}">Edit</a>
+    {% endif %}
+{% endblock %}
+
+{% block body %}
+    <h2>Create Ticket by...</h2>
+    <p>
+        <a href="{% url "votes:tickets_id" %}"
+           class="btn btn-outline-success btn-block">
+            ID list
+        </a>
+    </p>
+    <h2>Delete Tickets</h2>
+    <p>
+        <a href="{% url "votes:tickets_delete" %}"
+           class="btn btn-outline-danger btn-block">
+            Delete Tickets
+        </a>
+    </p>
+{% endblock %}

--- a/votes/templatetags/vote_tags.py
+++ b/votes/templatetags/vote_tags.py
@@ -1,0 +1,27 @@
+import hashlib
+import math
+import random
+
+from django import template
+from django.utils.safestring import mark_safe
+
+from votes.models import Election
+
+register = template.Library()
+
+
+@register.filter()
+def sanitized_vote_count(vote: Election):
+    value = vote.votes().count()
+    if value <= 5:
+        return mark_safe("&le; 5")
+    else:
+        return f"{math.floor(value/5)*5} - {math.ceil(value/5)*5}"
+
+
+@register.simple_tag(takes_context=True)
+def current_user_ticket(context, election: Election):
+    try:
+        return election.ticket_set.filter(member=context['user'].member).first()
+    except AttributeError:
+        return None

--- a/votes/urls.py
+++ b/votes/urls.py
@@ -1,27 +1,42 @@
-from django.contrib import admin
-from django.urls import path, include
+from django.urls import path
 
-from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, VoteView, FPTPResultView, FPTPVoteView, \
-    STVVoteView, STVResultView, STVAllVoteView, UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, TicketView, ResultView
+from .views import ApprovalVoteView, DoneView, ApprovalResultView, HomeView, \
+    VoteView, FPTPResultView, FPTPVoteView, STVVoteView, STVResultView, \
+    UpdateElection, CreateElection, CreateCandidate, UpdateCandidate, AdminView, \
+    TicketView, ResultView, IDTicketView, STVAllVoteView, DeleteTicketView, \
+    ResetVoteView, CloseElectionView
 
 app_name = "votes"
 
 urlpatterns = [
     path('', HomeView.as_view(), name="elections"),
     path('<int:election>/', VoteView.as_view(), name="vote"),
-    path('<int:election>/approval/', ApprovalVoteView.as_view(), name="approval_vote"),
+    path('<int:election>/approval/',
+         ApprovalVoteView.as_view(), name="approval_vote"),
     path('<int:election>/fptp/', FPTPVoteView.as_view(), name="fptp_vote"),
     path('<int:election>/stv/', STVVoteView.as_view(), name="stv_vote"),
     path('<int:election>/<uuid:slug>/', DoneView.as_view(), name="vote_done"),
     path('<int:election>/results/', ResultView.as_view(), name="results"),
-    path('<int:election>/results/approval/', ApprovalResultView.as_view(), name="approval_results"),
-    path('<int:election>/results/fptp/', FPTPResultView.as_view(), name="fptp_results"),
-    path('<int:election>/results/stv/', STVResultView.as_view(), name="stv_results"),
-    path('<int:election>/results/stv/votes/', STVAllVoteView.as_view(), name="stv_all_votes"),
+    path('<int:election>/results/approval/',
+         ApprovalResultView.as_view(), name="approval_results"),
+    path('<int:election>/results/fptp/',
+         FPTPResultView.as_view(), name="fptp_results"),
+    path('<int:election>/results/stv/',
+         STVResultView.as_view(), name="stv_results"),
+    path('<int:election>/results/stv/votes/',
+         STVAllVoteView.as_view(), name="stv_all_votes"),
     path('admin/', AdminView.as_view(), name="admin"),
+    path('admin/reset_vote/', ResetVoteView.as_view(), name="reset_vote"),
     path('admin/tickets/', TicketView.as_view(), name="tickets"),
+    path('admin/tickets/id/', IDTicketView.as_view(), name="tickets_id"),
+    path('admin/tickets/delete/', DeleteTicketView.as_view(),
+         name="tickets_delete"),
     path('admin/create/', CreateElection.as_view(), name="create_election"),
-    path('admin/edit/<int:election>/', UpdateElection.as_view(), name="update_election"),
-    path('admin/edit/<int:election>/create/', CreateCandidate.as_view(), name="create_candidate"),
-    path('admin/edit/<int:election>/edit/<int:candidate>/', UpdateCandidate.as_view(), name="update_candidate"),
+    path('admin/edit/<int:election>/',
+         UpdateElection.as_view(), name="update_election"),
+    path('admin/edit/<int:election>/create/',
+         CreateCandidate.as_view(), name="create_candidate"),
+    path('admin/edit/<int:election>/edit/<int:candidate>/',
+         UpdateCandidate.as_view(), name="update_candidate"),
+    path('admin/close_all/', CloseElectionView.as_view(), name="close"),
 ]

--- a/votes/views.py
+++ b/votes/views.py
@@ -92,7 +92,7 @@ class ResetVoteView(PermissionRequiredMixin, FormView):
     success_url = reverse_lazy('votes:admin')
 
     def form_valid(self, form):
-        uuid = form['uuid']
+        uuid = form.cleaned_data['uuid']
         ticket = get_object_or_404(Ticket, uuid=uuid)
         if ticket.election.vote_type == Election.Types.FPTP:
             vote = get_object_or_404(FPTPVote, uuid=uuid)

--- a/votes/views.py
+++ b/votes/views.py
@@ -1,9 +1,12 @@
 import random
 from operator import itemgetter, attrgetter
 
-from django.shortcuts import render
+from django.contrib.messages import add_message
+from django.contrib.messages import constants as messages
+from django.db import transaction, DatabaseError
+from django.shortcuts import render, Http404
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.contrib.auth.mixins import LoginRequiredMixin, PermissionRequiredMixin, UserPassesTestMixin
 from django.urls import reverse_lazy
 from django.views.generic import View, TemplateView, ListView, DetailView, RedirectView, CreateView, UpdateView, \
@@ -11,8 +14,10 @@ from django.views.generic import View, TemplateView, ListView, DetailView, Redir
 from django.shortcuts import get_object_or_404, HttpResponseRedirect, reverse
 
 from uwcsvote.permissions import PERMS
-from .forms import ElectionForm, CandidateForm, DateTicketForm
-from .models import Election, STVVote, STVPreference, FPTPVote, APRVVote, Candidate, Ticket, Vote, STVResult
+from .forms import ElectionForm, CandidateForm, IDTicketForm, DeleteTicketForm, \
+    ResetVoteForm, NullForm
+from .models import Election, STVVote, STVPreference, FPTPVote, APRVVote, \
+    Candidate, Ticket, Vote, STVResult
 from .stv import Election as StvCalculator
 
 
@@ -23,8 +28,13 @@ class HomeView(LoginRequiredMixin, ListView):
     context_object_name = "elections"
 
     def get_queryset(self):
-        tickets = self.request.user.member.ticket_set.filter(spent=False)
+        tickets = self.request.user.member.ticket_set.filter()
         return Election.objects.filter(ticket__in=tickets, open=True)
+
+    def get_context_data(self, *args, **kwargs):
+        ctxt = super().get_context_data(*args, **kwargs)
+        ctxt['tickets'] = self.request.user.member.ticket_set.filter()
+        return ctxt
 
 
 class AdminView(PermissionRequiredMixin, ListView):
@@ -34,20 +44,84 @@ class AdminView(PermissionRequiredMixin, ListView):
     context_object_name = "elections"
 
     def get_queryset(self):
-        return Election.objects.filter(archived=False)
+        return Election.objects.filter(archived=False).order_by('id')
+
+    def get_context_data(self, *args, **kwargs):
+        ctxt = super().get_context_data(*args, **kwargs)
+        ctxt['open_elections'] = self.get_queryset().filter(open=True)
+        ctxt['closed_elections'] = self.get_queryset().filter(
+            Q(stvvote__isnull=False) | Q(aprvvote__isnull=False) | Q(fptpvote__isnull=False),
+            open=False).distinct()
+        return ctxt
 
 
-class TicketView(PermissionRequiredMixin, FormView):
+class TicketView(PermissionRequiredMixin, TemplateView):
     permission_required = PERMS.votes.add_ticket
-    form_class = DateTicketForm
+    template_name = "votes/ticket.html"
+
+
+class IDTicketView(PermissionRequiredMixin, FormView):
+    permission_required = PERMS.votes.add_ticket
+    form_class = IDTicketForm
     template_name = "votes/tickets.html"
     success_url = reverse_lazy('votes:admin')
 
     def form_valid(self, form):
-
         for uniid in form.cleaned_data['ids'].split():
             for election in form.cleaned_data['elections']:
                 Ticket.objects.get_or_create(member=uniid, election=election)
+        return super().form_valid(form)
+
+
+class DeleteTicketView(PermissionRequiredMixin, FormView):
+    permission_required = PERMS.votes.delete_ticket
+    form_class = DeleteTicketForm
+    template_name = "votes/delete_tickets.html"
+    success_url = reverse_lazy('votes:admin')
+
+    def form_valid(self, form):
+        for election in form.cleaned_data['elections']:
+            Ticket.objects.filter(election=election).delete()
+        return super().form_valid(form)
+
+
+class ResetVoteView(PermissionRequiredMixin, FormView):
+    permission_required = PERMS.votes.change_ticket
+    form_class = ResetVoteForm
+    template_name = "votes/reset_vote.html"
+    success_url = reverse_lazy('votes:admin')
+
+    def form_valid(self, form):
+        uuid = form['uuid']
+        ticket = get_object_or_404(Ticket, uuid=uuid)
+        if ticket.election.vote_type == Election.Types.FPTP:
+            vote = get_object_or_404(FPTPVote, uuid=uuid)
+        elif ticket.election.vote_type == Election.Types.STV:
+            vote = get_object_or_404(STVVote, uuid=uuid)
+        elif ticket.election.vote_type == Election.Types.APRV:
+            vote = get_object_or_404(APRVVote, uuid=uuid)
+        else:
+            raise Http404()
+        try:
+            with transaction.atomic():
+                vote.delete()
+                ticket.spent = False
+                ticket.save()
+        except DatabaseError:
+            add_message(self.request, messages.ERROR, "Unable to delete vote")
+
+        return super().form_valid(form)
+
+
+class CloseElectionView(PermissionRequiredMixin, FormView):
+    permission_required = PERMS.votes.change_election
+    form_class = NullForm
+    template_name = "votes/ticket.html"
+    success_url = reverse_lazy('votes:admin')
+
+    def form_valid(self, form):
+        Election.objects.filter(open=True, archived=False).update(open=False)
+        add_message(self.request, messages.SUCCESS, "All votes closed")
         return super().form_valid(form)
 
 
@@ -82,7 +156,8 @@ class CreateCandidate(PermissionRequiredMixin, CreateView):
         return reverse("votes:update_election", args=[self.kwargs['election']])
 
     def form_valid(self, form):
-        form.instance.election = get_object_or_404(Election, id=self.kwargs['election'])
+        form.instance.election = get_object_or_404(
+            Election, id=self.kwargs['election'])
         return super().form_valid(form)
 
 
@@ -124,7 +199,8 @@ class VoteView(LoginRequiredMixin, RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         election = self.get_object()
         if election.vote_type == Election.Types.APRV:
-            return reverse('votes:approval_vote', args=[self.kwargs['election']])
+            return reverse('votes:approval_vote',
+                           args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.FPTP:
             return reverse('votes:fptp_vote', args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.STV:
@@ -142,7 +218,8 @@ class ResultView(PermissionRequiredMixin, RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         election = self.get_object()
         if election.vote_type == Election.Types.APRV:
-            return reverse('votes:approval_results', args=[self.kwargs['election']])
+            return reverse('votes:approval_results',
+                           args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.FPTP:
             return reverse('votes:fptp_results', args=[self.kwargs['election']])
         elif election.vote_type == Election.Types.STV:
@@ -159,14 +236,16 @@ class ApprovalResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.APRV,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.APRV,
                                           open=False)
         return self.election.candidate_set.all()
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
         ctxt['election'] = self.election
-        ctxt['choices'] = sorted(ctxt['choices'], key=lambda x: -x.votes().count())
+        ctxt['choices'] = sorted(
+            ctxt['choices'], key=lambda x: -x.votes().count())
         return ctxt
 
 
@@ -182,8 +261,8 @@ class ApprovalVoteView(UserPassesTestMixin, TemplateView):
 
     def post(self, request, **kwargs):
         self.get_context_data(**kwargs)
-        ticket = get_object_or_404(request.user.member.ticket_set.all(), election=self.election, spent=False)
-        print(request.POST)
+        ticket = get_object_or_404(
+            request.user.member.ticket_set.all(), election=self.election, spent=False)
         errors = []
         if "selection" not in request.POST:
             errors.append("Please select at least one option")
@@ -235,14 +314,16 @@ class FPTPResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.FPTP,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.FPTP,
                                           open=False)
         return self.election.candidate_set.all()
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
         ctxt['election'] = self.election
-        ctxt['choices'] = sorted(ctxt['choices'], key=lambda x: -x.votes().count())
+        ctxt['choices'] = sorted(
+            ctxt['choices'], key=lambda x: -x.votes().count())
         return ctxt
 
 
@@ -252,13 +333,17 @@ class FPTPVoteView(UserPassesTestMixin, TemplateView):
     def test_func(self):
         if self.request.user.is_anonymous:
             return False
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          open=True,
                                           vote_type=Election.Types.FPTP)
-        return self.request.user.member.ticket_set.filter(election=self.election, spent=False).exists()
+        return self.request.user.member.ticket_set.filter(
+            election=self.election, spent=False).exists()
 
     def post(self, request, **kwargs):
         self.get_context_data(**kwargs)
-        ticket = get_object_or_404(request.user.member.ticket_set.all(), election=self.election, spent=False)
+        ticket = get_object_or_404(
+            request.user.member.ticket_set.all(), election=self.election,
+            spent=False)
         print(request.POST)
         errors = []
         if "selection" not in request.POST:
@@ -288,11 +373,13 @@ class FPTPVoteView(UserPassesTestMixin, TemplateView):
             ticket.save()
 
             return HttpResponseRedirect(
-                reverse("votes:vote_done", kwargs={'election': self.election.id, 'slug': vote.uuid}))
+                reverse("votes:vote_done", kwargs={'election': self.election.id,
+                                                   'slug': vote.uuid}))
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          open=True,
                                           vote_type=Election.Types.FPTP)
         ctxt['election'] = self.election
         ctxt['choices'] = list(self.election.candidate_set.all())
@@ -307,7 +394,8 @@ class STVResultView(PermissionRequiredMixin, ListView):
     context_object_name = "choices"
 
     def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.STV,
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.STV,
                                           open=False)
         return self.election.candidate_set.all()
 
@@ -317,39 +405,27 @@ class STVResultView(PermissionRequiredMixin, ListView):
         try:
             res = self.election.stvresult
         except STVResult.DoesNotExist:
-            candidates = set(map(attrgetter('id'), self.election.candidate_set.all()))
-            withdrawn = set(map(attrgetter('id'), self.election.candidate_set.filter(state=Candidate.State.WITHDRAWN)))
+            candidates = set(
+                map(attrgetter('id'), self.election.candidate_set.all()))
+            withdrawn = set(
+                map(attrgetter('id'), self.election.candidate_set.filter(
+                    state=Candidate.State.WITHDRAWN)))
             votes = []
             for i in self.election.stvvote_set.all():
                 vote = []
-                for j in STVPreference.objects.filter(stvvote=i).order_by('order'):
+                for j in STVPreference.objects.filter(stvvote=i).order_by(
+                        'order'):
                     vote.append(int(j.candidate_id))
                 votes.append(tuple(vote))
 
             calc = StvCalculator(candidates, votes, self.election.seats)
             calc.withdraw(withdrawn)
             calc.full_election()
-            res = STVResult.objects.create(election=self.election, full_log="\n".join(calc.fulllog))
+            res = STVResult.objects.create(
+                election=self.election, full_log="\n".join(calc.fulllog))
             res.save()
             res.winners.add(*Candidate.objects.filter(id__in=calc.winners()))
         ctxt['result'] = res
-        return ctxt
-
-
-class STVAllVoteView(PermissionRequiredMixin, ListView):
-    model = Candidate
-    permission_required = PERMS.votes.view_stvvote
-    template_name = "votes/stv_vote_list.html"
-    context_object_name = "choices"
-
-    def get_queryset(self):
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], vote_type=Election.Types.STV,
-                                          open=False)
-        return self.election.candidate_set.all()
-
-    def get_context_data(self, **kwargs):
-        ctxt = super().get_context_data(**kwargs)
-        ctxt['election'] = self.election
         return ctxt
 
 
@@ -359,19 +435,26 @@ class STVVoteView(UserPassesTestMixin, TemplateView):
     def test_func(self):
         if self.request.user.is_anonymous:
             return False
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True, vote_type=Election.Types.STV)
-        return self.request.user.member.ticket_set.filter(election=self.election, spent=False).exists()
+        self.election = get_object_or_404(
+            Election, id=self.kwargs['election'], open=True,
+            vote_type=Election.Types.STV)
+        return self.request.user.member.ticket_set.filter(
+            election=self.election, spent=False).exists()
 
     def post(self, request, **kwargs):
         self.get_context_data(**kwargs)
-        ticket = get_object_or_404(request.user.member.ticket_set.all(), election=self.election, spent=False)
+        ticket = get_object_or_404(
+            request.user.member.ticket_set.all(),
+            election=self.election,
+            spent=False)
         print(request.POST)
         errors = []
         allowed = set(a.id for a in self.election.candidate_set.all())
 
         # Almost all of these errors should never be seen (unless someone is bypassing the js)
         submitted_candidates = set(request.POST.keys())
-        submitted_candidates.remove('csrfmiddlewaretoken')  # remove csrf token (the only valid non-vote value)
+        # remove csrf token (the only valid non-vote value)
+        submitted_candidates.remove('csrfmiddlewaretoken')
         try:
             submitted_candidates = set(map(int, submitted_candidates))
         except ValueError:
@@ -396,7 +479,8 @@ class STVVoteView(UserPassesTestMixin, TemplateView):
         if len(selection) != len(set(map(itemgetter(1), selection))):
             errors.append("Invalid preference (repeated)")
         if len(selection) == 0:
-            errors.append("Please select at least one candidate")  # This one is actually possible
+            # This one is actually possible
+            errors.append("Please select at least one candidate")
 
         if errors:
             return self.get(request, errors=set(errors), previous=request.POST)
@@ -407,20 +491,42 @@ class STVVoteView(UserPassesTestMixin, TemplateView):
             )
             vote.save()
             for i in selection:
-                STVPreference.objects.create(stvvote=vote, candidate_id=i[0], order=i[1])
+                STVPreference.objects.create(
+                    stvvote=vote, candidate_id=i[0], order=i[1])
 
             ticket.spent = True
             ticket.save()
 
             return HttpResponseRedirect(
-                reverse("votes:vote_done", kwargs={'election': self.election.id, 'slug': vote.uuid}))
+                reverse("votes:vote_done",
+                        kwargs={'election': self.election.id,
+                                'slug': vote.uuid}))
 
     def get_context_data(self, **kwargs):
         ctxt = super().get_context_data(**kwargs)
-        self.election = get_object_or_404(Election, id=self.kwargs['election'], open=True, vote_type=Election.Types.STV)
+        self.election = get_object_or_404(
+            Election, id=self.kwargs['election'], open=True, vote_type=Election.Types.STV)
         ctxt['election'] = self.election
         ctxt['choices'] = list(self.election.candidate_set.all())
         random.shuffle(ctxt['choices'])
+        return ctxt
+
+
+class STVAllVoteView(PermissionRequiredMixin, ListView):
+    model = Candidate
+    permission_required = PERMS.votes.view_stvvote
+    template_name = "votes/stv_vote_list.html"
+    context_object_name = "choices"
+
+    def get_queryset(self):
+        self.election = get_object_or_404(Election, id=self.kwargs['election'],
+                                          vote_type=Election.Types.STV,
+                                          open=False)
+        return self.election.candidate_set.all()
+
+    def get_context_data(self, **kwargs):
+        ctxt = super().get_context_data(**kwargs)
+        ctxt['election'] = self.election
         return ctxt
 
 


### PR DESCRIPTION
Incorporates some historic changes, as well as new changes from https://github.com/WarwickTabletop/tgrsite/pull/323/
Bolds STV vote options to make more clear
Adds a key for stv breakdowns so you don't have to look it up
Adds a big easy button for deleting tickets at end of vote (so that you don't get 500 errors when deleting too many tickets)
Shows approximate vote counts for active votes (chunked to 5 votes)
Hides bits of the admin page when empty
Allows users to still see votes they voted in on the dashboard page while the election is active (grayed out and unclickable)
Adds a dedicated UI for resetting a vote from UUID. This helps prevent you from doing it wrong, as well as accidentally seeing the vote itself
Adds a button to close all active votes.